### PR TITLE
remove redundant body-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/rpiambulance/whoson#readme",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "cachios": "^2.2.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1"

--- a/server.js
+++ b/server.js
@@ -1,7 +1,6 @@
 //node packages
 const express = require("express");
 const axios = require("cachios");
-const bodyParser = require("body-parser");
 require("dotenv").config();
 
 //local packages
@@ -9,8 +8,8 @@ const { getDate } = require("./utilities/helpers.js");
 
 //node package config
 const app = express();
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
 
 //globals
 const RPIA_WEB_TOKEN = process.env.RPIA_WEB_TOKEN;


### PR DESCRIPTION
For express@^4.16, the body-parser was re-added as a core dependency, and there is no reason to install it separately anymore. This redundancy is further expressed in that the removal of the package from the package.json did not change the package-lock.json.